### PR TITLE
Now using Zstandard instead of xz for package...

### DIFF
--- a/install-gns3.sh
+++ b/install-gns3.sh
@@ -89,7 +89,7 @@ $my_separator
   sleep 2
 
   cd "$my_repo_folder"/pkg/vpcs || exit
-  makepkg -sCf && sudo pacman -U vpcs-0.8beta1-1-x86_64.pkg.tar.xz --needed --noconfirm
+  makepkg -sCf && sudo pacman -U vpcs-0.8beta1-1-x86_64.pkg.tar.zst --needed --noconfirm
 
   cd "$HOME" || exit
   if [[ -z $(which vpcs) ]]; then


### PR DESCRIPTION
Now using Zstandard instead of xz for package compression
https://archlinux.org/news/now-using-zstandard-instead-of-xz-for-package-compression/